### PR TITLE
Support removing speakers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -98,7 +98,7 @@ const { newPhotos, updatedSpeakers } = reconcileSpeakers(
   websiteSpeakers
 );
 
-const updatedTalks = reconcileTalks(
+const { updatedTalks, removedTalks } = reconcileTalks(
   targetEvent,
   airtableSpeakers,
   websiteTalks
@@ -115,6 +115,7 @@ reconcileEvents(targetEvent, websiteEvents);
 const confirmation = await confirmUpdate(
   updatedSpeakers,
   updatedTalks,
+  removedTalks,
   updatedSponsors
 );
 if (confirmation) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "npm run build && node ./bin/index.js",
     "test": "npm run build && mocha test ./bin/test/*.spec.js",
     "build": "tsc --build",
-    "lint": "prettier ./**/*.ts --write && eslint ./**/*.ts --fix"
+    "lint": "eslint ./**/*.ts --fix && prettier ./**/*.ts --write"
   },
   "dependencies": {
     "airtable": "^0.11.6",

--- a/src/repos/user-input.ts
+++ b/src/repos/user-input.ts
@@ -56,12 +56,16 @@ export const getTargetEvent = async (
 export const confirmUpdate = async (
   updatedSpeakers: WebsiteSpeaker[],
   updatedTalks: WebsiteTalk[],
+  removedTalks: string[],
   updatedSponsors: WebsiteSponsor[]
 ): Promise<boolean> => {
-  const confirmMessage = ["Confirm update:\n"];
-  confirmMessage.push(`${updatedSpeakers.length} new speakers\n`);
-  confirmMessage.push(`${updatedTalks.length} new talks\n`);
-  confirmMessage.push(`${updatedSponsors.length} new sponsors\n`);
+  const confirmMessage = [
+    "Confirm update:\n",
+    `${updatedTalks.length} new talks\n`,
+    `${removedTalks.length} removed talks ${ removedTalks.length ? `(${removedTalks})` : ''}\n`,
+    `${updatedSponsors.length} new sponsors\n`,
+    `${updatedSpeakers.length} new speakers\n`
+  ];
   const res = await prompts({
     type: "confirm",
     name: "confirmUpdate",

--- a/src/speakers.ts
+++ b/src/speakers.ts
@@ -85,9 +85,10 @@ export const getEventSpeakers = (
   const speakerIds = (airtableEvent.get("Speakers") as string[]) || [];
   for (const speakerId of speakerIds) {
     // cartesian product runtime (O(a * b)), naughty naughty
-    speakerRecords.push(
-      airtableSpeakers.find((speaker) => speakerId == speaker.id)
-    );
+    const result = airtableSpeakers.find((speaker) => speakerId == speaker.id);
+    if (result) {
+      speakerRecords.push(result);
+    }
   }
   return speakerRecords;
 };

--- a/src/talks.ts
+++ b/src/talks.ts
@@ -12,8 +12,12 @@ export const reconcileTalks = (
   event: WebsiteAirtablePair,
   airtableSpeakers: Record<FieldSet>[],
   websiteTalks: WebsiteTalk[]
-): WebsiteTalk[] => {
+): {
+  updatedTalks: WebsiteTalk[];
+  removedTalks: string[];
+} => {
   const newTalks = [];
+  const removedTalks = [];
   const airtableEventSpeakers = getEventSpeakers(
     event.airtable,
     airtableSpeakers
@@ -34,7 +38,16 @@ export const reconcileTalks = (
       updatedTalks.push(newTalk);
     }
   }
-  return updatedTalks;
+  // handle the case where a speaker is removed for a conflict, etc
+  for (const webTalk of event.website.talks) {
+    if (!newTalks.find((newTalk) => newTalk.id === webTalk)) {
+      removedTalks.push(webTalk);
+    }
+  }
+  event.website.talks = event.website.talks.filter((talkid) =>
+    newTalks.find((newTalk) => newTalk.id === talkid)
+  );
+  return { updatedTalks, removedTalks };
 };
 
 const makeWebsiteTalk = (

--- a/test/speakers.spec.ts
+++ b/test/speakers.spec.ts
@@ -56,24 +56,4 @@ describe("reconcileSpeakers", function () {
       );
     });
   });
-  describe("should handle removing a speaker from existing speakers", function () {
-    const airSpeakers = airtableSpeakers.filter(speaker => !speaker.id.includes("cristina"))
-    const { removedSpeakers } = reconcileSpeakers(
-      targetEvent,
-      airSpeakers,
-      websiteSpeakers
-    );
-    it("returns the right number of speakers", function () {
-        assert(
-            removedSpeakers.length === 1,
-            `returned ${removedSpeakers.length} instead of 1`
-        );
-    });
-    it("returns the correct speaker", function () {
-        assert(
-            removedSpeakers.find(speaker => speaker.id.includes("cristina")),
-            "reconcileSpeakers() didn't return the removed speaker"
-        );
-    });
-  });
 });

--- a/test/speakers.spec.ts
+++ b/test/speakers.spec.ts
@@ -56,4 +56,24 @@ describe("reconcileSpeakers", function () {
       );
     });
   });
+  describe("should handle removing a speaker from existing speakers", function () {
+    const airSpeakers = airtableSpeakers.filter(speaker => !speaker.id.includes("cristina"))
+    const { removedSpeakers } = reconcileSpeakers(
+      targetEvent,
+      airSpeakers,
+      websiteSpeakers
+    );
+    it("returns the right number of speakers", function () {
+        assert(
+            removedSpeakers.length === 1,
+            `returned ${removedSpeakers.length} instead of 1`
+        );
+    });
+    it("returns the correct speaker", function () {
+        assert(
+            removedSpeakers.find(speaker => speaker.id.includes("cristina")),
+            "reconcileSpeakers() didn't return the removed speaker"
+        );
+    });
+  });
 });

--- a/test/talks.spec.ts
+++ b/test/talks.spec.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from "node:assert";
 // in June 2023, @types/lodash has an infinite loop when compiling with tsc
+// see: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/63022#issuecomment-1605954005
 import _ from "lodash";
 import {
   targetEvent,
@@ -19,7 +20,11 @@ describe("reconcileTalks", function () {
     const te = _.cloneDeep(targetEvent);
     te.website.talks = [];
     const emptyWebTalks = [];
-    const updatedTalks = reconcileTalks(te, airtableSpeakers, emptyWebTalks);
+    const { updatedTalks } = reconcileTalks(
+      te,
+      airtableSpeakers,
+      emptyWebTalks
+    );
     it("should return the right talks", function () {
       const updatedTalkIds = updatedTalks.map((talk) => talk.id);
       assert(
@@ -51,7 +56,7 @@ describe("reconcileTalks", function () {
     // remove aiden from talks json
     const webTalks = websiteTalks.filter((talk) => !talk.id.includes("aiden"));
 
-    const updatedTalks = reconcileTalks(te, airtableSpeakers, webTalks);
+    const { updatedTalks } = reconcileTalks(te, airtableSpeakers, webTalks);
     const correctTalkId = "aiden-bai-june-2023";
     it("should return the right talks", function () {
       const updatedTalkIds = updatedTalks.map((talk) => talk.id);
@@ -81,7 +86,7 @@ describe("reconcileTalks", function () {
     te.websiteTalks = te.website.talks.filter(
       (talkId) => !talkId.includes("dm-liao")
     );
-    const updatedTalks = reconcileTalks(te, airtableSpeakers, websiteTalks);
+    const { updatedTalks } = reconcileTalks(te, airtableSpeakers, websiteTalks);
     it("should return no talks to update", function () {
       assert(
         updatedTalks.length === 0,
@@ -96,6 +101,28 @@ describe("reconcileTalks", function () {
       assert(
         te.website.talks.every((id) => correctTalkIds.includes(id)),
         `correct talks: ${correctTalkIds} doesn't match event talks: ${te.website.talks}`
+      );
+    });
+  });
+  describe("should handle removing talks when speakers can't make it", function () {
+    const te = _.cloneDeep(targetEvent);
+    let as = _.cloneDeep(airtableSpeakers);
+    // remove one of the speakers from airtable to simulate a speaker who can't make it
+    as = as.filter(
+      (speaker) => !speaker.get("Full Name").toLowerCase().includes("liao")
+    );
+
+    const { removedTalks } = reconcileTalks(te, as, websiteTalks);
+    it("should return the correct number of removed talks", function () {
+      assert(
+        removedTalks.length === 1,
+        `${removedTalks.length} removed talks were returned, expected 1`
+      );
+    });
+    it("should update the event json", function () {
+      assert(
+        te.website.talks.length === 2,
+        `event has ${te.website.talks.length} instead of 2`
       );
     });
   });


### PR DESCRIPTION
We had a speaker that needed to reschedule, so it's important to support that use case.

This new functionality doesn't delete any speaker data or photos, it only removes the speaker from the event json.
