### PR TITLE
remove node 14x from the workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "seattlejs-data-pipeline",
+  "name": "seattlejs-airtable-cli",
   "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "seattlejs-data-pipeline",
+      "name": "seattlejs-airtable-cli",
       "version": "1.0.5",
       "dependencies": {
         "airtable": "^0.11.6",
@@ -17,7 +17,7 @@
         "yargs": "^17.7.2"
       },
       "bin": {
-        "seattle-airtable-cli": "bin/index.js"
+        "seattlejs-airtable-cli": "bin/index.js"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.1",


### PR DESCRIPTION
Don't currently support node 14 and nvm doesn't have a binary for it for macOS arm. And node takes a loooooooong time to compile.