### PR TITLE
Fix talk topics, publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - run: npm run build
+      - run: npm run test
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seattlejs-airtable-cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "seattlejs-airtable-cli",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "airtable": "^0.11.6",
         "jimp": "^0.22.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seattlejs-airtable-cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "seattlejs-airtable-cli",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "airtable": "^0.11.6",
         "jimp": "^0.22.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seattlejs-airtable-cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "data pipeline for producing seattlejs website data",
   "type": "module",
   "main": "./bin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seattlejs-airtable-cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "data pipeline for producing seattlejs website data",
   "type": "module",
   "main": "./bin/index.js",

--- a/src/normalizers.ts
+++ b/src/normalizers.ts
@@ -69,3 +69,15 @@ export const normalizeTalkType = (
   }
   return "lightning";
 };
+
+export const handleTalkTopics = (
+  talkTopics: string | undefined | ""
+): string[] => {
+  if (talkTopics === "") {
+    return [];
+  }
+  if (typeof talkTopics === "undefined") {
+    return [];
+  }
+  return talkTopics.split(", ");
+};

--- a/src/talks.ts
+++ b/src/talks.ts
@@ -4,6 +4,7 @@ import {
   makeTalkId,
   makeEventId,
   normalizeTalkType,
+  handleTalkTopics,
 } from "./normalizers.js";
 import { WebsiteTalk, WebsiteAirtablePair } from "./repos/website-types.js";
 import { getEventSpeakers } from "./speakers.js";
@@ -66,7 +67,7 @@ const makeWebsiteTalk = (
   talk.event_id = eventId;
   talk.title = (airtableSpeaker.get("Talk Title") as string) || "";
   talk.abstract = (airtableSpeaker.get("Talk Blurb") as string) || "";
-  talk.topics = airtableSpeaker.get("Topics") as string[];
+  talk.topics = handleTalkTopics(airtableSpeaker.get("Topics") as string);
   talk.type = talkType;
   return talk;
 };

--- a/test/normalizers.test.ts
+++ b/test/normalizers.test.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from "node:assert";
+import { airtableSpeakers } from "./june-2023-sample-data.js";
+import { handleTalkTopics } from "../src/normalizers.js";
+
+describe("getTalkTopics", function () {
+  describe("should handle when topics exist", function () {
+    const topics = handleTalkTopics(
+      airtableSpeakers[0].get("Topics") as string
+    );
+    const expectedTopics = (airtableSpeakers[0].get("Topics") as string).split(
+      ", "
+    );
+    assert(
+      topics === expectedTopics,
+      `topics ${topics} did not match ${expectedTopics}`
+    );
+  });
+  describe("should handle when topics don't exist", function () {
+    const undefinedTopics = handleTalkTopics(undefined);
+    const emptyStringTopics = handleTalkTopics("");
+    assert(
+      Array.isArray(undefinedTopics) && undefinedTopics.length === 0,
+      "should handle undefined"
+    );
+    assert(
+      Array.isArray(emptyStringTopics) && emptyStringTopics.length === 0,
+      "should handle empty string"
+    );
+  });
+});


### PR DESCRIPTION
The talk topics needed to be a string array, not a comma-separated string.

Also, the publish workflow was missing a `npm build`. Threw in a `npm test` for good measure, though it's probably redundant.