### PR TITLE
Add job names to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,4 @@
 name: Node.js CI
-
 on:
   push:
     branches: [ main ]
@@ -8,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: ci
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: ci
+    name: CI
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
     types: [published]
 jobs:
   build:
+    name: release publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
     types: [published]
 jobs:
   build:
-    name: release publish
+    name: npm publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This helps discoverability for branch protection checks. See https://stackoverflow.com/questions/68554735/github-action-status-check-missing-from-the-list-of-checks-in-protected-branch-s